### PR TITLE
Fix stick calibration

### DIFF
--- a/hid-nx.c
+++ b/hid-nx.c
@@ -1029,6 +1029,12 @@ static int nx_con_read_stick_calibration(struct nx_con *con,
 		y_max_above = hid_field_extract(con->hdev, (raw + 7), 4, 12);
 	}
 
+	/* SPI min/max calibration is relative to center */
+	cal_x->max = cal_x->center + x_max_above;
+	cal_x->min = cal_x->center - x_min_below;
+	cal_y->max = cal_y->center + y_max_above;
+	cal_y->min = cal_y->center - y_min_below;
+
 	/* check if calibration values are plausible */
 	if (cal_x->min >= cal_x->center || 
 	    cal_x->center >= cal_x->max ||


### PR DESCRIPTION
I was experiencing issues #8 / #18 on my NSO N64 controler.
Digging in the code, I found that min/max calibration are not properly set during nx_con_read_stick_calibration().
Hence, it always returned EINVAL (because output calibration values don't satisfy "min < center < max").

According to [dekuNukem joycon reverse engineering](https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/spi_flash_notes.md#:~:text=The%20minimum%20and%20maximum%20values%20are%20then%20subtracted%20or%20added%20to%20the%20center%20values%20to%20get%20the%20real%20Min/Max%20range.), the min and max values read from SPI are relative to the center.

So the actual calibration values should be center-min < center < center+max.
